### PR TITLE
Fix OAuth1Client: yarl.quote only takes a Mapping[str,str]

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -202,7 +202,7 @@ class OAuth1Client(Client):
             'oauth_consumer_key': self.consumer_key,
             'oauth_nonce': sha1(str(random()).encode('ascii')).hexdigest(),
             'oauth_signature_method': self.signature.name,
-            'oauth_timestamp': int(time.time()),
+            'oauth_timestamp': str(int(time.time())),
             'oauth_version': self.version,
         }
         oparams.update(params or {})


### PR DESCRIPTION
All is in the title :) current Twitter clients fails with:

```python
  File "/Users/arthur/Documents/reaaad/nightfort/nightfort/http/auth.py", line 324, in get
    token, _, __ = await client.get_request_token(oauth_callback=callback)
  File "/Users/arthur/Documents/reaaad/nightfort/.venv/lib/python3.5/site-packages/aioauth_client.py", line 228, in get_request_token
    response = yield from self.request('GET', self.request_token_url, params=params, loop=loop)
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/tasks.py", line 386, in wait_for
    return fut.result()
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/Users/arthur/Documents/reaaad/nightfort/.venv/lib/python3.5/site-packages/aiohttp/client.py", line 198, in _request
    proxy=proxy, proxy_auth=proxy_auth, timeout=timeout)
  File "/Users/arthur/Documents/reaaad/nightfort/.venv/lib/python3.5/site-packages/aiohttp/client_reqrep.py", line 79, in __init__
    url2 = url.with_query(params)
  File "/Users/arthur/Documents/reaaad/nightfort/.venv/lib/python3.5/site-packages/yarl/__init__.py", line 611, in with_query
    for k, v in query.items())
  File "/Users/arthur/Documents/reaaad/nightfort/.venv/lib/python3.5/site-packages/yarl/__init__.py", line 611, in <genexpr>
    for k, v in query.items())
  File "yarl/_quoting.pyx", line 46, in yarl._quoting._quote (yarl/_quoting.c:1384)
TypeError: Argument should be str
```