### PR TITLE
Update vk urls

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -814,8 +814,8 @@ class VKClient(OAuth2Client):
     * API reference: http://vk.com/developers.php?oid=-17680044&p=API_Method_Description
     """
 
-    authorize_url = 'http://api.vkontakte.ru/oauth/authorize'
-    access_token_url = 'https://api.vkontakte.ru/oauth/access_token'
+    authorize_url = 'http://api.vk.com/oauth/authorize'
+    access_token_url = 'https://api.vk.com/oauth/access_token'
     user_info_url = 'https://api.vk.com/method/getProfiles?fields=uid,first_name,last_name,nickname,sex,bdate,city,country,timezone,photo_big'  # noqa
     name = 'vk'
     base_url = 'https://api.vk.com'


### PR DESCRIPTION
Update vk urls due to invalidation of api.vkontakte.ru (ssl cert expired) in favor of api.vk.com
Signed-off-by: Ivan Kolomiets <ieee802@yandex.ru>