### PR TITLE
aiohttp 3.0.0 doesn't exist for Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: 3.4
+python: 3.5
 
 branches:
     only:


### PR DESCRIPTION
From the release notes:

> Drop Python 3.4 and Python 3.5.0, 3.5.1, 3.5.2. Minimal supported Python versions are 3.5.3 and 3.6.0. yield from is gone, use async/await syntax. (#2343)