### PR TITLE
Fix TypeError: object tuple can't be used in 'await' expression

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -505,7 +505,7 @@ class LichessClient(OAuth2Client):
         if self.access_token:
             headers['Authorization'] = "Bearer {}".format(self.access_token)
 
-        return self._request(method, url, headers=headers, **aio_kwargs),
+        return self._request(method, url, headers=headers, **aio_kwargs)
 
 
 class Meetup(OAuth1Client):


### PR DESCRIPTION
Heh. The same mistake what I fixed in Bitbucket2Client left in my previous PR.