### PR TITLE
Switch from deprecated Google+ Sign-in API to Google Sign-in API

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -840,9 +840,9 @@ class GoogleClient(OAuth2Client):
 
     authorize_url = 'https://accounts.google.com/o/oauth2/v2/auth'
     access_token_url = 'https://www.googleapis.com/oauth2/v4/token'
-    base_url = 'https://www.googleapis.com/plus/v1/'
+    base_url = 'https://www.googleapis.com/userinfo/v2/'
     name = 'google'
-    user_info_url = 'https://www.googleapis.com/plus/v1/people/me'
+    user_info_url = 'https://www.googleapis.com/userinfo/v2/me'
 
     @staticmethod
     def user_parse(data):
@@ -854,9 +854,6 @@ class GoogleClient(OAuth2Client):
         yield 'locale', data.get('language')
         yield 'link', data.get('url')
         yield 'picture', data.get('image', {}).get('url')
-        for email in data.get('emails', []):
-            if email['type'] == 'account':
-                yield 'email', email['value']
 
 
 class VKClient(OAuth2Client):


### PR DESCRIPTION
"On March 7, 2019, all Google+ APIs and Google+ Sign-in will be shut down completely. This will be a progressive shutdown beginning in late January, with calls to these APIs starting to intermittently fail as early as January 28, 2019."

As a result, calls to https://www.googleapis.com/plus/v1/people/me are getting flagged.