### PR TITLE
Patch for VK - Client should request with version number explicitly.

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -875,9 +875,10 @@ class VKClient(OAuth2Client):
     name = 'vk'
     base_url = 'https://api.vk.com'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, version='5.9.2', *args, **kwargs):
         """Set default scope."""
         super(VKClient, self).__init__(*args, **kwargs)
+        self.user_info_url = f"{self.user_info_url}&v={version}"
         self.params.setdefault('scope', 'offline')
 
     @staticmethod

--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -878,7 +878,7 @@ class VKClient(OAuth2Client):
     def __init__(self, version='5.9.2', *args, **kwargs):
         """Set default scope."""
         super(VKClient, self).__init__(*args, **kwargs)
-        self.user_info_url = f"{self.user_info_url}&v={version}"
+        self.user_info_url = "{0}&v={1}".format(self.user_info_url, version)
         self.params.setdefault('scope', 'offline')
 
     @staticmethod


### PR DESCRIPTION
Vk API requires version number explicitly.
If the version number does not exist, an error will be returned.
Default version number is 5.9.2.

Please refer to https://vk.com/dev/version_update for more information.