### PR TITLE
potential fix for #119

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -310,7 +310,10 @@ class OAuth2Client(Client):
 
         access_token = access_token or self.access_token
         if access_token:
-            params[self.access_token_key] = access_token
+            if isinstance(params, list):
+                params.append((self.access_token_key, access_token))
+            else:
+                params[self.access_token_key] = access_token
 
         headers = headers or {
             'Accept': 'application/json',


### PR DESCRIPTION
this PR allows sending query params with multiple values for the same key as described in [aiohttp client docs](https://docs.aiohttp.org/en/stable/client_quickstart.html#passing-parameters-in-urls)