### PR TITLE
avoid duplicate access_token in params

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -311,6 +311,10 @@ class OAuth2Client(Client):
         access_token = access_token or self.access_token
         if access_token:
             if isinstance(params, list):
+                params = [
+                    (key, value) for key, value in params
+                    if key != self.access_token_key
+                ]
                 params.append((self.access_token_key, access_token))
             else:
                 params[self.access_token_key] = access_token


### PR DESCRIPTION
This PR is a follow up on #119 and #120 to avoid adding multiple `access_token=123&access_token=123` as query parameters.

First remove the access_token_key from the list of params tuples. Then add it again.