### PR TITLE
don't raise HTTPBadRequest for 2XX status codes

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -145,7 +145,7 @@ class Client(object, metaclass=ClientRegistry):
         try:
             async with session.request(method, url, **kwargs) as response:
 
-                if response.status / 100 > 2:
+                if response.status // 100 > 2:
                     raise web.HTTPBadRequest(
                         reason='HTTP status code: %s' % response.status)
 


### PR DESCRIPTION
2xx: Success - The action was successfully received, understood, and accepted 
[iana.org HTTP Status Codes](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)