### PR TITLE
add Gitlab client to main code

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -1087,4 +1087,35 @@ class MicrosoftClient(OAuth2Client):
         yield 'email', data.get('userPrincipalName')
 
 
+class GitlabClient(OAuth2Client):
+    """Support GitLab.
+
+    * Dashboard: https://gitlab.com/-/profile/applications
+    * Docs: https://docs.gitlab.com/ee/integration/oauth_provider.html
+    """
+
+    access_token_url = 'https://gitlab.com/oauth/token'
+    authorize_url = 'https://gitlab.com/oauth/authorize'
+    base_url = 'https://gitlab.com/api/v4'
+    name = 'gitlab'
+    user_info_url = 'https://gitlab.com/api/v4/user'
+
+    @staticmethod
+    def user_parse(data):
+        """Parse information from provider."""
+        yield 'id', data.get('id')
+        yield 'email', data.get('email')
+        first_name, _, last_name = (data.get('name') or '').partition(' ')
+        yield 'first_name', first_name
+        yield 'last_name', last_name
+        yield 'username', data.get('username')
+        yield 'picture', data.get('avatar_url')
+        yield 'link', data.get('web_url')
+        location = data.get('location', '')
+        if location:
+            split_location = location.split(',')
+            yield 'country', split_location[0].strip()
+            if len(split_location) > 1:
+                yield 'city', split_location[1].strip()
+
 # pylama:ignore=E501


### PR DESCRIPTION
Hello, I have created this PR to add GitLab support. This is a fairly non-controversial change; I merely added a `GitlabClient` class with the requisite URLs.

I had to update my `setup.cfg` with a `[tox:tox]` directive, and also noticed that the `Client` class uses a python2-incompatible metaclass constructor. If you still care about supporting Python2, I could make a separate PR to implement compatibility via six (https://python-future.org/compatible_idioms.html#metaclasses).

Tox tests passed for python 3.