### PR TITLE
Add missing (GET) params to OAuth2Client.request

### DIFF
--- a/aioauth_client.py
+++ b/aioauth_client.py
@@ -299,7 +299,7 @@ class OAuth2Client(Client):
         if access_token:
             headers.setdefault('Authorization', 'Bearer %s' % access_token)
 
-        return self._request(method, url, headers=headers, **options)
+        return self._request(method, url, headers=headers, params=params, **options)
 
     async def get_access_token(self, code: str, redirect_uri: str = None,
                                headers: t.Dict = None, **payload) -> t.Tuple[str, t.Any]:


### PR DESCRIPTION
When calling the `request` method with `params` dict, the dict is not converted
to GET parameters (e.g. `params={"foo": "bar"}` to `f"{url}?foo=bar"`).
Current workaround is to include it in the url.

This is caused by the method `request` in class `OAuth2Client` not passing on
the option `params`. One way to fix this would be to pass it implicitly by
removing `params: t.Dict = None` from the options.

I opted for the more explicit fix and passing `params=params` to the `_request`
method.