### PR TITLE
Fix HMAC-SHA1 signature

### DIFF
--- a/aioauth_client/__init__.py
+++ b/aioauth_client/__init__.py
@@ -73,7 +73,7 @@ class HmacSha1Signature(Signature):
             query_string = '&'.join(['%s=%s' % item for item in sorted(query)])
 
         else:
-            query_string = urlencode(params)
+            query_string = urlencode(sorted(params.items()))
 
         signature = "&".join(map(self._escape, (method.upper(), url, query_string)))
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,0 +1,21 @@
+from aioauth_client import HmacSha1Signature
+
+
+def test_hmac_sha1_signature():
+    signer = HmacSha1Signature()
+
+    signature = signer.sign(
+        consumer_secret='consumer_secret',
+        method='GET',
+        url='https://site.com/endpoint.json',
+        oauth_token_secret='oauth_token_secret',
+        escape=False,
+        oauth_consumer_key='blablabla',
+        oauth_nonce='blublublu',
+        oauth_signature_method='HMAC-SHA1',
+        oauth_timestamp='1644067741',
+        oauth_version='1.0',
+        tweet_mode='extended',
+        oauth_token='bliblibli',
+    )
+    assert signature == "eqgTuU6+8g4Op1Cyu0QWk+watto="


### PR DESCRIPTION
Since aioauth-client 0.25.7, my Twitter client is failing to retrieve tweets
with an error 401 not authorized, without any change in our code.

I finally took some time to investigate this further, and I found out that,
with the same inputs, the HMAC-SHA1 signature changes between these versions.
I'm not at all familiar with these signature algorithms, but it looks like the
URL parameters used in the signature were sorted before, while they are not in
recent versions of aioauth-client.

This PR first adds a test for the HMAC-SHA1 signature component, and then makes
it pass by re-ordering the URLs params as before. The expected result of the
test has been obtained with aioauth-client 0.25.6 (which is known to be working
for me) and with the provided patch, my twitter client is working again.
